### PR TITLE
Исправление битых символов при транслитерации

### DIFF
--- a/core/components/ytranslit/model/modx/ytranslit/modtransliterate.class.php
+++ b/core/components/ytranslit/model/modx/ytranslit/modtransliterate.class.php
@@ -57,7 +57,7 @@ class modTransliterate
         }
 
         $trim = $this->modx->getOption('friendly_alias_trim_chars', null, '/.-_', true);
-        $string = str_replace(str_split($trim), ' ', $string);
+        $string = mb_ereg_replace(str_split($trim), ' ', $string);
 
         $service = $this->modx->getOption('friendly_alias_ytranslit_url', null,
             'https://translate.yandex.net/api/v1.5/tr.json/translate?key=[[+key]]&lang=ru-en&text=', true);


### PR DESCRIPTION
Если в настройке **friendly_alias_trim_chars** есть многобайтовые символы (например, `»`), то замена с помощью _str_replace_ генерирует битые символы. Например, если в заголовке есть буква `л`